### PR TITLE
Fix issue with CSP in Sidekiq 7.2.3+

### DIFF
--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -57,7 +57,7 @@
 </form>
 
 <% if @presented_job.require_confirm %>
-  <script>
+  <script type="text/javascript" <%= defined?(:csp_nonce) && "nonce=\"#{csp_nonce}\""%>>
     document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
       const confirmPrompt = "<%= @presented_job.confirm_prompt_message %>";
       const input = prompt(`Please enter "${confirmPrompt}" to confirm`);

--- a/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
+++ b/spec/sidekiq_adhoc_job/requests/jobs/show_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
   include_context 'SidekiqAdhocJob setup'
   include_context 'request setup'
 
+  def check_script_csp_nonce(response_body = last_response.body)
+    if Sidekiq::VERSION >= '7.3.0'
+      expect(response_body).to include("nonce=\"#{last_request.env[:csp_nonce]}\"")
+    end
+  end
+
   context 'has arguments' do
     it 'generates form for running job' do
       get '/adhoc-jobs/sidekiq_adhoc_job_test_dummy_worker'
@@ -70,6 +76,8 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
           HTML
         )
       )
+
+      check_script_csp_nonce(response_body)
     end
   end
 
@@ -114,6 +122,8 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
           HTML
         )
       )
+
+      check_script_csp_nonce(response_body)
     end
   end
 
@@ -134,6 +144,8 @@ RSpec.describe 'GET /adhoc_jobs/:name' do
       )
 
       expect(response_body).to include('<p>No job arguments</p>')
+
+      check_script_csp_nonce(response_body)
     end
   end
 


### PR DESCRIPTION
Fix https://github.com/gohkhoonhiang/sidekiq_adhoc_job/issues/40

Due to this change in https://github.com/sidekiq/sidekiq/blob/main/Changes.md#730:
> SECURITY The Web UI no longer allows extensions to use `<script>`. Adjust CSP to disallow inline scripts within the Web UI. Please see `examples/webui-ext `for how to register Web UI extensions and use dynamic CSS and JS. This will make Sidekiq immune to XSS attacks.

The browser will raise this error on `/adhoc-jobs/:name` page:
```
Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-...'". Either the 'unsafe-inline' keyword, a hash ('sha256-zNVp0L/oKh3an3bfFAJUvulO5vvLQra9kLKPJGZcILs='), or a nonce ('nonce-...') is required to enable inline execution.
```

As a result, the confirm popup will not show and the job will run right away with no confirmation.